### PR TITLE
Add Elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Supports
   * [Kemel](crystal/kemel)
   * [Shard](crystal/shard)
   * [Spectator](crystal/spectator)
+* [Elixir](elixir)
 * [Go](go)
 * [HTML / CSS / JavaScript](html)
 * [Java](java)
@@ -52,7 +53,6 @@ Missing
 * ActionScript
 * C# / Mono
 * Erlang
-* Elixir
 * Haskell
 * [JNLP](http://docs.oracle.com/javase/tutorial/deployment/applet/deployingApplet.html)
 * OCaml

--- a/elixir/Makefile
+++ b/elixir/Makefile
@@ -1,0 +1,4 @@
+ELIXIR=elixir
+
+test: test.exs
+	$(ELIXIR) test.exs

--- a/elixir/test.exs
+++ b/elixir/test.exs
@@ -1,0 +1,2 @@
+# elixir test.exs
+IO.puts("test")

--- a/elixir/test.exs
+++ b/elixir/test.exs
@@ -1,2 +1,1 @@
-# elixir test.exs
 IO.puts("test")


### PR DESCRIPTION
Starting with the most basic example. Elixir is both compiled (`.ex) and interpreted (`.exs`), depending on the file type so I choose not to use a `Makefile` with the first example. `Makefiles` aren't used in the Elixir ecosystem, but I can add one to the examples, just LMK.